### PR TITLE
Some applications require that characters in the URL contain slashes …

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1305,6 +1305,7 @@ function encodeUriQuery(val, pctEncodeSpaces) {
              replace(/%24/g, '$').
              replace(/%2C/gi, ',').
              replace(/%3B/gi, ';').
+             replace(/%2F/gi, '/').
              replace(/%20/g, (pctEncodeSpaces ? '%20' : '+'));
 }
 


### PR DESCRIPTION
…in order to function correctly.

Doofinder uses slashes in its urls but $location currently encodes slashes. This causes unwanted redirects

This fix adds "/" to the list of characters to decode after queries or URLs are encoded.

# AngularJS is in LTS mode
We are no longer accepting changes that are not critical bug fixes into this project.
See https://blog.angular.io/stable-angularjs-and-long-term-support-7e077635ee9c for more detail.

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**Does this PR fix a regression since 1.7.0, a security flaw, or a problem caused by a new browser version?**

<!-- If the answer is no, then we will not merge this PR -->


**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

